### PR TITLE
Add bashrc file (initial revision)

### DIFF
--- a/terminal/.bashrc
+++ b/terminal/.bashrc
@@ -1,0 +1,8 @@
+# Avoid duplicates
+export HISTCONTROL=ignoredups:erasedups
+
+# When the shell exits, append to the history file instead of overwriting it
+shopt -s histappend
+
+# After each command, append to the history file and reread it
+export PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND$'\n'}history -a; history -c; history -r"

--- a/terminal/Dockerfile
+++ b/terminal/Dockerfile
@@ -105,6 +105,7 @@ RUN mkdir -p /opt/app-root/etc/init.d && \
     fix-permissions /opt/app-root
 
 COPY .bash_profile /opt/app-root/src/.bash_profile
+COPY .bashrc /opt/app-root/src/.bashrc
 
 RUN virtualenv /opt/app-root && \
     source /opt/app-root/bin/activate && \


### PR DESCRIPTION
Have bash immediately add commands to our history instead of waiting for the end of each session (to enable commands in one terminal to be instantly be available in another).

When Bash is invoked as an interactive non-login shell, it reads and executes commands from ~/.bashrc, if that file exists, and it is readable.

Put the commands that should run every time you launch a new shell in the .bashrc file. This include your aliases and functions , custom prompts, history customizations , and so on.